### PR TITLE
issue取得の際にlabelも含まれていたため、label取得リクエストを破棄

### DIFF
--- a/issue_calculator.rb
+++ b/issue_calculator.rb
@@ -20,8 +20,7 @@ class IssueCalculator
   def sum_point
     points = []
     @issues.each do |issue|
-      labels = @client.labels_for_issue(Config.instance.repository_name, issue.number)
-      labels.each do |label|
+      (issue['labels'] || []).each do |label|
         if label.name =~ /^[0-9]+$/
           points << label.name.to_i
         end


### PR DESCRIPTION
## 概要
issueごとにlabelを取得するリクエストを投げていたが、実はissue取得したタイミングでlabel内容が含まれていた。
そのためlabel取得リクエストを削除し、パフォーマンスの改善を測った。

## 確認内容

同一マイストーンに対しての数値が変更前と変更後で変わらないことを確認