### PR TITLE
設定ファイル名を指定して実行できるようにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,9 @@ exec
 ```
 bundle exec ruby milestone.rb
 ```
+
+specific file exec
+
+```
+bundle exec ruby milestone.rb milestone.yml
+```

--- a/config.rb
+++ b/config.rb
@@ -4,13 +4,19 @@ class Config
   attr_reader :repository_name, :milestone_name, :token, :started_on, :default_throughput, :work_start_time, :work_end_time
 
   class << self
+
+    def setup(path = 'config.yml')
+      @path = path
+      @instance = new(@path)
+    end
+
     def instance
-      @instance ||= new
+      @instance ||= setup
     end
   end
 
-  def initialize
-    config = YAML.load_file('config.yml')
+  def initialize(path)
+    config = YAML.load_file(path)
 
     @repository_name = config['repository_name']
     @milestone_name = config['milestone_name']

--- a/milestone.rb
+++ b/milestone.rb
@@ -6,6 +6,8 @@ require './string_ajust'
 
 GITHUB_PER_PAGE_NUM = 100
 
+Config.setup ARGV[0]
+
 def find_milestone(client, milestone_name)
   client.list_milestones(config.repository_name).find { |m| m.title == config.milestone_name }
 end


### PR DESCRIPTION
## 概要

現在`config.yml`に記載したmilestoneだけ実行可能であり、複数のmilestoneを管理できなかった。

その為実行時に設定ファイルを指定できるようにした

## 確認内容
```
MacBook-Pro-2:issue_reporter kurubushionline$ bundle exec ruby milestone.rb milestone2.yml 
################################################
マイルストーン       : XXXXX
作業開始日           : 2020-01-17
実装終了日           : 2020-01-27
総作業日数           : 7日
消化日数             : 1.8日
残日数               : 5.2日
残ポイント           : 62
終了ポイント         : 3
現在スループット     : 2 / 日
初期想定スループット : 15 / 日
リームーポイント     : 51.6
################################################
MacBook-Pro-2:issue_reporter kurubushionline$ bundle exec ruby milestone.rb milestone1.yml 
################################################
マイルストーン       : XXXX
作業開始日           : 2020-01-31
実装終了日           : 2020-02-10
総作業日数           : 7日
消化日数             : 0.8日
残日数               : 15.2日
残ポイント           : 9
終了ポイント         : 0
現在スループット     : 0 / 日
初期想定スループット : 15 / 日
リームーポイント     : 9.0
################################################

```